### PR TITLE
define srcs for validation in local_copy

### DIFF
--- a/parallel_sync/rsync.py
+++ b/parallel_sync/rsync.py
@@ -219,7 +219,9 @@ def local_copy(paths, parallelism=10, extract=False, validate=False):
     """
     @paths: list of tuples of (source_path, dest_path)
     """
+    srcs = []
     for src, dst in paths:
+        srcs.append(src)
         dst_dir = os.path.dirname(os.path.expanduser(dst))
         if not os.path.exists(dst_dir):
             os.makedirs(dst_dir)


### PR DESCRIPTION
local copy source validation fails to validate because sources is not defined.  i made a bug report here. https://github.com/kouroshparsa/parallel_sync/issues/13 

this is my proposed fix.

alternatively I could simply replace srcs with paths as it seems to have a similar effect.